### PR TITLE
Fix: #tag foreground not visible in preview mode (edit mode was OK)

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -100,10 +100,6 @@ pre.HyperMD-codeblock {
     color: var(--text-highlight-fg) !important;
 }
 
-.cm-hashtag {
-    color: var(--text-accent) !important;
-}
-
 blockquote, .markdown-embed {
     border-color: var(--text-border) !important;
 }


### PR DESCRIPTION
Fixes the following problem:
The #tag pill is only visible in Preview mode:
![image](https://user-images.githubusercontent.com/4393698/83328094-e897d680-a280-11ea-98e6-1cfed9a2caed.png)


But not in Edit mode:
![image](https://user-images.githubusercontent.com/4393698/83328086-dfa70500-a280-11ea-84bc-bcc816a7a3e2.png)
