### PR TITLE
Fix search match highlight

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -39,7 +39,8 @@
     --interactive-accent-rgb: var(--green);
     --vim-cursor: var(--green);
     --text-border: var(--yellow);
-
+    --search-match-highlight-fg: var(--red);
+    --search-match-highlight-bg: var(--base3);
 }
 
 .theme-light {
@@ -66,7 +67,8 @@
     --text-on-accent: var(--base3);
     --vim-cursor: var(--green);
     --text-border: var(--yellow);
-
+    --search-match-highlight-fg: var(--base3);
+    --search-match-highlight-bg: var(--red);
 }
 
 .cm-header {
@@ -135,4 +137,9 @@ a.tag {
 .cm-s-obsidian span.cm-hashtag-end {
     border-radius: 0px 10px 10px 0px;
     padding-left: 0px;
+}
+
+.obsidian-search-match-highlight {
+    color: var(--search-match-highlight-fg);
+    background-color: var(--search-match-highlight-bg);
 }

--- a/obsidian.css
+++ b/obsidian.css
@@ -100,10 +100,6 @@ pre.HyperMD-codeblock {
     color: var(--text-highlight-fg) !important;
 }
 
-.cm-hashtag {
-    color: var(--text-accent) !important;
-}
-
 blockquote, .markdown-embed {
     border-color: var(--text-border) !important;
 }


### PR DESCRIPTION
Fix: Make highlight for CTRL+F search results visible.
Hint: CTRL+F search currently only available in Edit Mode (not in Preview Mode)

New display: On dark background:
![image](https://user-images.githubusercontent.com/4393698/83329382-6e1f8480-a289-11ea-82aa-4dc06396594e.png)


New Display on light background
![image](https://user-images.githubusercontent.com/4393698/83329363-5811c400-a289-11ea-8c62-9d3a39911f46.png)

