### PR TITLE
fix background color of frontmatter tags, issue #13

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -193,6 +193,11 @@ a.tag {
     padding: 2px 5px;
 }
 
+/* Background color of tag when hover */
+a.tag:hover {
+    background-color: var(--text-accent-hover);
+}
+
 /* Frontmatter */
 .cm-s-obsidian span.cm-atom {
     color: var(--text-accent);
@@ -201,6 +206,15 @@ a.tag {
 .cm-s-obsidian span.cm-meta,
 .cm-s-obsidian span.cm-def {
     color: var(--text-code);
+}
+
+/* Frontmatter tag colors, same as tags in main body */
+.frontmatter-container .tag {
+    background-color: var(--text-normal);
+}
+
+.frontmatter-container .tag:hover {
+    background-color: var(--text-accent-hover);
 }
 
 /* Selection & search results */


### PR DESCRIPTION
before fix:
<img width="331" alt="before_fix_dart" src="https://user-images.githubusercontent.com/14011748/128993783-ac8aed2d-626a-4915-b875-98741b8f070a.png">
<img width="307" alt="before_fix_light" src="https://user-images.githubusercontent.com/14011748/128993790-c3e8da5e-283b-41b4-b0cb-e8dcdcfba4a2.png">

after fix:
<img width="288" alt="after_fix_dark" src="https://user-images.githubusercontent.com/14011748/128993848-da2b79bb-36eb-4341-a8f1-504e500214bb.png">
<img width="305" alt="after_fix_light" src="https://user-images.githubusercontent.com/14011748/128993861-0d4ee806-d2a4-4b49-a5e2-712ba7601aa1.png">
