### PR TITLE
Header Text No Longer Cyan in Reader Mode after Obsidian 0.15.6

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -115,6 +115,10 @@
     color: var(--text-title);
 }
 
+[data-heading] {
+    color: var(--text-title) !important;
+}
+
 h1,
 h2,
 h3,


### PR DESCRIPTION
@harmtemolder 
I added a new selector to fix color for headers in a reading mode

pls let me know if it should be updated: I'm not a css guy